### PR TITLE
Add structured JSON format for AI visit summary

### DIFF
--- a/app/src/main/java/org/intelehealth/app/ai/formatter/VisitSummaryAiFormatter.kt
+++ b/app/src/main/java/org/intelehealth/app/ai/formatter/VisitSummaryAiFormatter.kt
@@ -1,0 +1,358 @@
+package org.intelehealth.app.ai.formatter
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.intelehealth.app.app.IntelehealthApplication
+import org.intelehealth.app.database.dao.ObsDAO
+import org.intelehealth.app.knowledgeEngine.Node
+import org.intelehealth.app.models.VitalsObject
+import org.intelehealth.app.models.dto.ObsDTO
+import org.intelehealth.app.utilities.CustomLog
+import org.intelehealth.app.utilities.SessionManager
+import org.intelehealth.app.utilities.StringUtils
+import org.intelehealth.app.utilities.UuidDictionary
+import org.intelehealth.app.utilities.exception.DAOException
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * @author: Nagen Biswal
+ * @date 2026-08-12
+ *
+ * Single entry point for turning a visit's captured form data into the AI backend's
+ * structured JSON (see Temp.json for the target shape) and persisting it as the
+ * visit's consolidated AI-summary obs.
+ *
+ * The Node-tree walking, the JSON assembly, and the DB save all live in this one
+ * file/package on purpose: dropping org.intelehealth.app.ai.formatter into another
+ * project (plus its Node/ObsDAO/UuidDictionary/SessionManager dependencies) should
+ * be enough to get this feature working there too.
+ *
+ * Key mapping is auto-derived from each Node's display text (snake_cased) rather
+ * than matched against Temp.json's exact field names (site/radiation/etc.) - revisit
+ * [toSnakeCase] / [buildQuestionGroup] once real node data is available and the
+ * generated keys need to line up with a fixed backend contract.
+ */
+object VisitSummaryAiFormatter {
+
+    private const val TAG = "VisitSummaryAiFormatter"
+
+    /**
+     * Builds the AI-summary JSON from the visit's captured data and saves it under
+     * [encounterUuid] as the [UuidDictionary.AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID] obs.
+     *
+     * [patientSex]/[patientAgeYears] aren't part of the four Node-tree sections but
+     * are required for the demographic block - pass through whatever the caller
+     * already has for the patient.
+     *
+     * @return the JSON that was saved, or null if the DB write failed.
+     */
+    @JvmStatic
+    fun formatAndSave(
+        encounterUuid: String,
+        patientSex: String?,
+        patientAgeYears: Int?,
+        vital: VitalsObject?,
+        chiefComplaintNodes: List<Node>?,
+        physicalExamNodes: List<Node>?,
+        patientHistoryNodes: List<Node>?,
+        familyHistoryNodes: List<Node>?
+    ): JSONObject? {
+        val json = buildAiSummaryJson(
+            patientSex,
+            patientAgeYears,
+            vital,
+            chiefComplaintNodes,
+            physicalExamNodes,
+            patientHistoryNodes,
+            familyHistoryNodes
+        )
+        return if (saveAiSummaryToDb(encounterUuid, json)) json else null
+    }
+
+    // ---------------------------------------------------------------------------
+    // JSON assembly
+    // ---------------------------------------------------------------------------
+
+    private fun buildAiSummaryJson(
+        patientSex: String?,
+        patientAgeYears: Int?,
+        vital: VitalsObject?,
+        chiefComplaintNodes: List<Node>?,
+        physicalExamNodes: List<Node>?,
+        patientHistoryNodes: List<Node>?,
+        familyHistoryNodes: List<Node>?
+    ): JSONObject {
+        val extraction = JSONObject()
+        extraction.put("demographic", buildDemographic(patientSex, patientAgeYears, vital))
+        extraction.put("chief_complaint", buildChiefComplaint(chiefComplaintNodes))
+        extraction.put("associated_symptom", buildAssociatedSymptoms(chiefComplaintNodes))
+        extraction.put("history", buildHistory(patientHistoryNodes, familyHistoryNodes))
+        extraction.put("physical_examination", buildPhysicalExamination(physicalExamNodes))
+
+        val root = JSONObject()
+        root.put("extraction", extraction)
+        return root
+    }
+
+    private fun buildDemographic(sex: String?, age: Int?, vital: VitalsObject?): JSONObject {
+        val demographic = JSONObject()
+        demographic.put("sex", sex ?: JSONObject.NULL)
+        demographic.put("age", age ?: JSONObject.NULL)
+        demographic.put("vital", buildVital(vital))
+        return demographic
+    }
+
+    private fun buildVital(vital: VitalsObject?): JSONObject {
+        val json = JSONObject()
+        json.put("sbp", numericOrNull(vital?.bpsys))
+        json.put("dbp", numericOrNull(vital?.bpdia))
+        json.put("pulse", numericOrNull(vital?.pulse))
+        json.put("rr", numericOrNull(vital?.resp))
+        json.put("spo2", numericOrNull(vital?.spo2))
+        json.put("weight", numericOrNull(vital?.weight))
+        json.put("height", numericOrNull(vital?.height))
+        json.put("temp", numericOrNull(vital?.temperature))
+        json.put("bmi", numericOrNull(vital?.bmi))
+        return json
+    }
+
+    /**
+     * Root complaint categories (e.g. "Abdominal Pain") are always present in
+     * [nodes] whether or not the nurse actually filled them in - same as the
+     * legacy formatComplainRecord() walk - so this processes every category
+     * unconditionally and only keeps the ones that produced answered fields.
+     */
+    private fun buildChiefComplaint(nodes: List<Node>?): JSONArray {
+        val array = JSONArray()
+        nodes.orEmpty()
+            .filter { !it.text.equals(Node.ASSOCIATE_SYMPTOMS, ignoreCase = true) }
+            .forEach { symptomNode ->
+                val symptom = nodeText(symptomNode) ?: return@forEach
+                val fields = buildProtocolFields(symptomNode)
+                if (fields.length() > 0) {
+                    val entry = JSONObject()
+                    entry.put("symptom", symptom)
+                    entry.put("protocol_fields", fields)
+                    array.put(entry)
+                }
+            }
+        return array
+    }
+
+    private fun buildProtocolFields(symptomNode: Node): JSONObject {
+        val fields = JSONObject()
+        collectAnsweredFields(symptomNode.optionsList, fields)
+        return fields
+    }
+
+    /**
+     * Walks the symptom's protocol questions (Site, Duration, ...). Each question's
+     * own isSelected() only means "answered somewhere below" - not "this is the
+     * picked value" (same convention the UI's chip adapters use) - so the real
+     * answer always comes from [resolveValue], keyed by the QUESTION's own text.
+     */
+    private fun collectAnsweredFields(nodes: List<Node>?, into: JSONObject) {
+        nodes.orEmpty().forEach { node ->
+            if (!node.isSelected) return@forEach
+            val key = nodeText(node)?.let { toSnakeCase(it) } ?: return@forEach
+            val answer = resolveValue(node) ?: return@forEach
+            into.put(key, answer)
+        }
+    }
+
+    /**
+     * Resolves a Question node down to its answer: a terminal node (no further
+     * choices, e.g. free text/date input) carries its own answer via getLanguage();
+     * a branching node's answer is whichever child has isSelected == true. If that
+     * selected child is itself just a plain terminal pick (e.g. a Site chip like
+     * "Middle (C) - Umbilical"), its text is used directly as the scalar answer.
+     * If the selected child is itself a further sub-question (e.g. "High Blood
+     * Pressure" -> "Diagnosed on" -> a date), it's nested under its own label
+     * instead of collapsing away - {"diagnosed_on": "12/Aug/2026"} - so answers
+     * with real follow-up structure don't lose that structure.
+     */
+    private fun resolveValue(node: Node): Any? {
+        val options = node.optionsList
+        if (node.isTerminal || options.isNullOrEmpty()) {
+            return nodeText(node)
+        }
+        val selectedChild = options.firstOrNull { it.isSelected } ?: return null
+        val childOptions = selectedChild.optionsList
+        if (selectedChild.isTerminal || childOptions.isNullOrEmpty()) {
+            return nodeText(selectedChild)
+        }
+        val nestedValue = resolveValue(selectedChild) ?: return nodeText(selectedChild)
+        val key = nodeText(selectedChild)?.let { toSnakeCase(it) } ?: "value"
+        val wrapped = JSONObject()
+        wrapped.put(key, nestedValue)
+        return wrapped
+    }
+
+    private fun buildAssociatedSymptoms(nodes: List<Node>?): JSONObject {
+        val associateNode = nodes.orEmpty()
+            .firstOrNull { it.text.equals(Node.ASSOCIATE_SYMPTOMS, ignoreCase = true) }
+        val present = JSONArray()
+        val absent = JSONArray()
+        associateNode?.optionsList.orEmpty().forEach { option ->
+            val label = nodeText(option) ?: return@forEach
+            when {
+                option.isSelected -> present.put(label)
+                option.isNoSelected -> absent.put(label)
+            }
+        }
+        val json = JSONObject()
+        json.put("present", present)
+        json.put("absent", absent)
+        return json
+    }
+
+    private fun buildHistory(patientHistoryNodes: List<Node>?, familyHistoryNodes: List<Node>?): JSONObject {
+        val history = JSONObject()
+        history.put("patient_history", buildQuestionGroup(patientHistoryNodes))
+        history.put("family_history", buildQuestionGroup(familyHistoryNodes))
+        return history
+    }
+
+    /**
+     * Generic converter for a flat list of top-level questions: a multi-choice
+     * question (e.g. "Medical History") becomes a nested object with one key per
+     * checkbox option; anything else is a single yes/no/free-text answer, resolved
+     * the same isSelected-chain way as chief-complaint protocol fields.
+     */
+    private fun buildQuestionGroup(nodes: List<Node>?): JSONObject {
+        val json = JSONObject()
+        nodes.orEmpty().forEach { node ->
+            val key = nodeText(node)?.let { toSnakeCase(it) } ?: return@forEach
+            val options = node.optionsList
+            json.put(
+                key,
+                if (node.isMultiChoice && !options.isNullOrEmpty()) {
+                    buildCheckboxGroup(options)
+                } else {
+                    resolveValue(node) ?: JSONObject.NULL
+                }
+            )
+        }
+        return json
+    }
+
+    private fun buildCheckboxGroup(options: List<Node>): JSONObject {
+        val group = JSONObject()
+        options.forEach { option ->
+            val key = nodeText(option)?.let { toSnakeCase(it) } ?: return@forEach
+            group.put(key, checkboxValue(option))
+        }
+        return group
+    }
+
+    /**
+     * A checkbox's own isSelected/isNoSelected IS the real "was this checked"
+     * signal (unlike a branching Question, where that flag only means "answered
+     * somewhere below"), so this checks it directly. A checked item with its own
+     * follow-up question (e.g. "High Blood Pressure" -> "Diagnosed on") nests it
+     * via [resolveValue] instead of collapsing to a bare checkmark.
+     */
+    private fun checkboxValue(option: Node): Any {
+        if (!option.isSelected && !option.isNoSelected) return JSONObject.NULL
+        val childOptions = option.optionsList
+        if (childOptions.isNullOrEmpty()) return nodeText(option) ?: ""
+        return resolveValue(option) ?: (nodeText(option) ?: "")
+    }
+
+    /** physicalExamNodes is PhysicalExam.getSelectedNodes() - the Location level. */
+    private fun buildPhysicalExamination(nodes: List<Node>?): JSONObject {
+        val findings = JSONArray()
+        collectExamFindings(nodes, findings)
+        val json = JSONObject()
+        json.put("findings", findings)
+        return json
+    }
+
+    /**
+     * Walks the whole physical-exam tree unconditionally (Location/Exam/Question,
+     * whatever the actual depth) rather than assuming a fixed container depth - a
+     * fixed 2-level skip under-counted findings because not every exam category
+     * nests the same number of levels. A node is recorded as a finding only when
+     * it has a directly selected child (a genuine answered Question), using
+     * [resolveValue] for the answer so follow-up sub-questions stay nested. Once a
+     * node is captured this way, [resolveValue] has already walked its entire
+     * selected chain, so recursion stops there instead of rediscovering the same
+     * leaf again as its own separate (and now orphaned-looking) entry.
+     */
+    private fun collectExamFindings(nodes: List<Node>?, into: JSONArray) {
+        nodes.orEmpty().forEach { node ->
+            val hasSelectedChild = node.optionsList.orEmpty().any { it.isSelected }
+            if (hasSelectedChild) {
+                val name = nodeText(node)
+                val answer = resolveValue(node)
+                if (name != null && answer != null) {
+                    val entry = JSONObject()
+                    entry.put("name", name)
+                    entry.put("answer", answer)
+                    into.put(entry)
+                    return@forEach
+                }
+            }
+            collectExamFindings(node.optionsList, into)
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Node text / value helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * A node's canonical text: prefer "language" (the filled-in typed/picked value)
+     * over the raw "text" label; "%" is a magic "no real value" placeholder used
+     * throughout the mind-map data, so a language of exactly "%" is skipped in
+     * favor of falling back to "text" rather than treating the whole node as blank.
+     */
+    private fun nodeText(node: Node): String? {
+        val language = node.language
+        val value = if (!language.isNullOrEmpty() && language != "%") language else node.text
+        return if (value.isNullOrBlank()) null else value
+    }
+
+    private fun toSnakeCase(text: String): String =
+        text.trim()
+            .lowercase()
+            .replace(Regex("[^a-z0-9]+"), "_")
+            .trim('_')
+
+    private fun numericOrNull(value: String?): Any {
+        if (value.isNullOrBlank()) return JSONObject.NULL
+        val number = value.toDoubleOrNull() ?: return value
+        return if (number == number.toLong().toDouble()) number.toLong() else number
+    }
+
+    // ---------------------------------------------------------------------------
+    // DB save
+    // ---------------------------------------------------------------------------
+
+    private fun saveAiSummaryToDb(encounterUuid: String, json: JSONObject): Boolean {
+        return try {
+            val sessionManager = SessionManager(IntelehealthApplication.getAppContext())
+            val obsDAO = ObsDAO()
+            val existingObsUuid = obsDAO.getObsuuid(encounterUuid, UuidDictionary.AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID)
+
+            val obsDTO = ObsDTO()
+            obsDTO.conceptuuid = UuidDictionary.AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID
+            obsDTO.encounteruuid = encounterUuid
+            obsDTO.creator = sessionManager.creatorID
+            obsDTO.value = StringUtils.getValue(json.toString())
+
+            val isSaved = if (existingObsUuid != null) {
+                obsDTO.uuid = existingObsUuid
+                obsDAO.updateObs(obsDTO)
+            } else {
+                obsDAO.insertObs(obsDTO)
+            }
+            CustomLog.i(TAG, "saveAiSummaryToDb: encounterUuid=$encounterUuid isSaved=$isSaved")
+            CustomLog.d(TAG, "saveAiSummaryToDb: json=${json.toString(2)}")
+            isSaved
+        } catch (e: DAOException) {
+            FirebaseCrashlytics.getInstance().recordException(e)
+            false
+        }
+    }
+}

--- a/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
+++ b/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
@@ -40,6 +40,7 @@ import com.google.gson.reflect.TypeToken;
 import org.intelehealth.app.BuildConfig;
 import org.intelehealth.app.R;
 import org.intelehealth.app.activities.visitSummaryActivity.VisitSummaryActivity_New;
+import org.intelehealth.app.ai.formatter.VisitSummaryAiFormatter;
 import org.intelehealth.app.app.AppConstants;
 import org.intelehealth.app.app.IntelehealthApplication;
 import org.intelehealth.app.ayu.visit.common.VisitUtils;
@@ -2193,6 +2194,8 @@ public class VisitCreationActivity extends BaseActivity implements VisitCreation
     }
 
     private boolean insertLocalEnFormatQAValues() {
+        //Need the formatted string to be inserted in the database for AI AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID concept
+        insertJsonFormattedVisitSummary();
         CustomLog.i(TAG, "insertLocalEnFormatQAValues");
         boolean isInserted = false;
         try {
@@ -2227,6 +2230,49 @@ public class VisitCreationActivity extends BaseActivity implements VisitCreation
 
         return isInserted;
     }
+    /**
+     * Inserts the visit summary in JSON format into the database for the AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID concept.
+     * This method is called from insertLocalEnFormatQAValues() to ensure that the visit summary is stored in a structured format for AI processing.
+     * The JSON structure should include the following fields: encounterAdultIntials, patientGender, age, vitals, chief complaints, physical examination, patient history, and family history.
+     * The method retrieves the necessary data from the member variables and formats it using the VisitSummaryAiFormatter class before saving it to the database.
+     * This allows for easy retrieval and processing of the visit summary in a machine-readable format for AI applications.
+     */
+    private void insertJsonFormattedVisitSummary() {
+        List<Node> patientHistoryNodes = mPastMedicalHistoryNode != null ? mPastMedicalHistoryNode.getOptionsList() : null;
+        List<Node> familyHistoryNodes = mFamilyHistoryNode != null ? mFamilyHistoryNode.getOptionsList() : null;
+        List<Node> physicalExamNodes = physicalExamMap != null ? physicalExamMap.getSelectedNodes() : null;
+
+        CustomLog.i(TAG, "insertJsonFormattedVisitSummary: mFamilyHistoryNode=" + (mFamilyHistoryNode == null ? "null" : "non-null")
+                + " familyHistoryNodes.size=" + (familyHistoryNodes == null ? "null" : familyHistoryNodes.size()));
+        if (familyHistoryNodes != null) {
+            for (Node node : familyHistoryNodes) {
+                CustomLog.i(TAG, "insertJsonFormattedVisitSummary: familyHistory node text=" + node.getText()
+                        + " language=" + node.getLanguage()
+                        + " isSelected=" + node.isSelected()
+                        + " optionsSize=" + (node.getOptionsList() == null ? "null" : node.getOptionsList().size()));
+            }
+        }
+
+        // check mVitalsObject is null  then load it from db
+        if (mVitalsObject == null) {
+            try {
+                mVitalsObject = new ObsDAO().getVitalsForEncounter(encounterVitals);
+            } catch (DAOException e) {
+                FirebaseCrashlytics.getInstance().recordException(e);
+            }
+        }
+        VisitSummaryAiFormatter.formatAndSave(
+                encounterAdultIntials,
+                patientGender,
+                (int) float_ageYear_Month,
+                mVitalsObject,
+                mChiefComplainRootNodeList,
+                physicalExamNodes,
+                patientHistoryNodes,
+                familyHistoryNodes
+        );
+    }
+
     /**
      * Fetches the existing VISIT_AI_SUPPORT_DATA obs value for this visit
      * and splits it back into the four ...LocaleEn member variables.

--- a/app/src/main/java/org/intelehealth/app/database/dao/ObsDAO.java
+++ b/app/src/main/java/org/intelehealth/app/database/dao/ObsDAO.java
@@ -2,8 +2,8 @@ package org.intelehealth.app.database.dao;
 
 import static org.intelehealth.app.utilities.UuidDictionary.ENCOUNTER_VISIT_COMPLETE;
 import static org.intelehealth.app.utilities.UuidDictionary.ENCOUNTER_VITALS;
-import static org.intelehealth.app.utilities.UuidDictionary.HW_FOLLOWUP_CONCEPT_ID;
 import static org.intelehealth.app.utilities.UuidDictionary.FOLLOW_UP_VISIT;
+import static org.intelehealth.app.utilities.UuidDictionary.HW_FOLLOWUP_CONCEPT_ID;
 import static org.intelehealth.app.utilities.UuidDictionary.OBS_TYPE_DIAGNOSTICS_SET;
 
 import android.content.ContentValues;
@@ -13,16 +13,15 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.util.Log;
 
-import org.intelehealth.app.models.dto.VisitDTO;
-import org.intelehealth.app.utilities.CustomLog;
-
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.google.gson.Gson;
 
 import org.intelehealth.app.activities.prescription.PrescDataModel;
 import org.intelehealth.app.app.AppConstants;
 import org.intelehealth.app.app.IntelehealthApplication;
+import org.intelehealth.app.models.VitalsObject;
 import org.intelehealth.app.models.dto.ObsDTO;
+import org.intelehealth.app.utilities.CustomLog;
 import org.intelehealth.app.utilities.Logger;
 import org.intelehealth.app.utilities.SessionManager;
 import org.intelehealth.app.utilities.UuidDictionary;
@@ -31,6 +30,7 @@ import org.intelehealth.app.utilities.exception.DAOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 public class ObsDAO extends BaseDao{
@@ -578,5 +578,40 @@ public class ObsDAO extends BaseDao{
             cursor.close();
         }
         return value;
+    }
+
+    /**
+     * Fetches the vitals for a given encounterUuid and returns a VitalsObject containing the values.
+     *
+     * @param encounterUuid
+     * @return VitalsObject containing the vitals values for the encounter
+     * @throws DAOException
+     */
+    public VitalsObject getVitalsForEncounter(String encounterUuid) throws DAOException {
+        VitalsObject vitalsObject = new VitalsObject();
+        vitalsObject.setHeight(getObsValue(encounterUuid, UuidDictionary.HEIGHT));
+        vitalsObject.setWeight(getObsValue(encounterUuid, UuidDictionary.WEIGHT));
+        vitalsObject.setPulse(getObsValue(encounterUuid, UuidDictionary.PULSE));
+        vitalsObject.setBpsys(getObsValue(encounterUuid, UuidDictionary.SYSTOLIC_BP));
+        vitalsObject.setBpdia(getObsValue(encounterUuid, UuidDictionary.DIASTOLIC_BP));
+        vitalsObject.setTemperature(getObsValue(encounterUuid, UuidDictionary.TEMPERATURE));
+        vitalsObject.setResp(getObsValue(encounterUuid, UuidDictionary.RESPIRATORY));
+        vitalsObject.setSpo2(getObsValue(encounterUuid, UuidDictionary.SPO2));
+        // bmi calculation
+        if (vitalsObject.getHeight() != null && vitalsObject.getWeight() != null) {
+            try {
+                // already in height in cm, weight kg, BMI = weight (kg) / (height (m))^2
+                double numerator = Double.parseDouble(vitalsObject.getWeight()) * 10000;
+                double denominator = Double.parseDouble(vitalsObject.getHeight()) * Double.parseDouble(vitalsObject.getHeight());
+                double bmi_value = numerator / denominator;
+                vitalsObject.setBmi(String.format(Locale.ENGLISH, "%.2f", bmi_value));
+
+            } catch (NumberFormatException e) {
+                FirebaseCrashlytics.getInstance().recordException(e);
+                vitalsObject.setBmi(null); // Set BMI to null if parsing fails
+            }
+        }
+
+        return vitalsObject;
     }
 }

--- a/app/src/main/java/org/intelehealth/app/utilities/UuidDictionary.java
+++ b/app/src/main/java/org/intelehealth/app/utilities/UuidDictionary.java
@@ -98,6 +98,8 @@ public class UuidDictionary {
     public static final String VISIT_BILLING_DETAILS = "7030c68e-eecc-4656-bb0a-e465aea6195f";
 
     public static final String AI_VISIT_SUMMARY_CONCEPT_UUID = "4fac8cc4-b2ed-4f1f-90fc-ea17eae1ba3d";
+    // concept uuid for the AI generated JSON format of the visit summary
+    public static final String AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID = "1f770363-262e-4d01-b1df-3eb164d575ef";
 
 
 }

--- a/endpoint.properties
+++ b/endpoint.properties
@@ -159,21 +159,21 @@ NAS_DEV_FB_RT_INSTANCE="dev.intelehealth.org"
 #NAS_STAGE_FB_RT_INSTANCE="astesting.intelehealth.org"
 
 ## NAS - Staging
-#NAS_STAGE_SERVER_URL="https://nasstaging.intelehealth.org"
-##NAS_STAGE_SERVER_URL="https://nasstagingnew.intelehealth.org"
-#NAS_STAGE_REAL_TIME_FB_URL="https://nashik-arogya-sampada-master-default-rtdb.asia-southeast1.firebasedatabase.app/"
-##NAS_STAGE_LIVE_KIT_URL="wss://nasstaging.intelehealth.org:9090"
-#NAS_STAGE_LIVE_KIT_URL="wss://arogya-sampada-l3ytb3ui.livekit.cloud"
-#NAS_STAGE_SOCKET_URL="https://nasstaging.intelehealth.org:3004"
-#NAS_STAGE_FB_RT_INSTANCE="nasstaging.intelehealth.org"
-
-NAS_STAGE_SERVER_URL="https://demoai.intelehealth.org"
+NAS_STAGE_SERVER_URL="https://nasstaging.intelehealth.org"
 #NAS_STAGE_SERVER_URL="https://nasstagingnew.intelehealth.org"
 NAS_STAGE_REAL_TIME_FB_URL="https://nashik-arogya-sampada-master-default-rtdb.asia-southeast1.firebasedatabase.app/"
-NAS_STAGE_LIVE_KIT_URL="wss://demoai.intelehealth.org:9090"
-#NAS_STAGE_LIVE_KIT_URL="wss://arogya-sampada-l3ytb3ui.livekit.cloud"
-NAS_STAGE_SOCKET_URL="https://demoai.intelehealth.org:3004"
+#NAS_STAGE_LIVE_KIT_URL="wss://nasstaging.intelehealth.org:9090"
+NAS_STAGE_LIVE_KIT_URL="wss://arogya-sampada-l3ytb3ui.livekit.cloud"
+NAS_STAGE_SOCKET_URL="https://nasstaging.intelehealth.org:3004"
 NAS_STAGE_FB_RT_INSTANCE="nasstaging.intelehealth.org"
+
+#NAS_STAGE_SERVER_URL="https://demoai.intelehealth.org"
+##NAS_STAGE_SERVER_URL="https://nasstagingnew.intelehealth.org"
+#NAS_STAGE_REAL_TIME_FB_URL="https://nashik-arogya-sampada-master-default-rtdb.asia-southeast1.firebasedatabase.app/"
+#NAS_STAGE_LIVE_KIT_URL="wss://demoai.intelehealth.org:9090"
+##NAS_STAGE_LIVE_KIT_URL="wss://arogya-sampada-l3ytb3ui.livekit.cloud"
+#NAS_STAGE_SOCKET_URL="https://demoai.intelehealth.org:3004"
+#NAS_STAGE_FB_RT_INSTANCE="nasstaging.intelehealth.org"
 
 
 # NAS - Production


### PR DESCRIPTION
Introduces VisitSummaryAiFormatter, which converts a visit's chief complaint, physical exam, patient history, and family history Node trees (plus vitals and demographics) into a nested JSON payload and saves it under the AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID concept, alongside the existing plain-text AI summary.