### PR TITLE
PR-990-NAS-1752: Store consent for Patient, Visit(Teleconsulation), and ABDM

### DIFF
--- a/app/src/main/java/org/intelehealth/app/activities/onboarding/PersonalConsentActivity.kt
+++ b/app/src/main/java/org/intelehealth/app/activities/onboarding/PersonalConsentActivity.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
 import androidx.core.view.WindowCompat
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.intelehealth.abdm.presentation.AbdmCardDownloader
 import org.intelehealth.abdm.presentation.AbdmLauncher
 import org.intelehealth.abdm.presentation.abha_choice.AbhaChoiceDialogFragment
@@ -24,13 +25,20 @@ import org.intelehealth.app.BuildConfig
 import org.intelehealth.app.R
 import org.intelehealth.app.activities.patientDetailActivity.PatientDetailActivity2
 import org.intelehealth.app.app.AppConstants
+import org.intelehealth.app.database.dao.PatientsDAO
+import org.intelehealth.app.models.dto.PatientAttributesDTO
 import org.intelehealth.app.ui.patient.activity.PatientRegistrationActivity
 import org.intelehealth.app.utilities.ConfigUtils
+import org.intelehealth.app.utilities.ConsentUtils
+import org.intelehealth.app.utilities.CustomLog
 import org.intelehealth.app.utilities.DialogUtils
 import org.intelehealth.app.utilities.FlavorKeys
 import org.intelehealth.app.utilities.SessionManager
+import org.intelehealth.app.utilities.UuidDictionary
 import org.intelehealth.app.utilities.WebViewStatus
+import org.intelehealth.app.utilities.exception.DAOException
 import java.util.Locale
+import java.util.UUID
 
 
 class PersonalConsentActivity : AppCompatActivity(), WebViewStatus {
@@ -40,6 +48,13 @@ class PersonalConsentActivity : AppCompatActivity(), WebViewStatus {
     private val context: Context = this
     private var sessionManager: SessionManager? = null
     private var loadingDialog: AlertDialog? = null
+
+    /**
+     * NAS-1752 - the Patient_Consent value, built the moment Accept is tapped. No patient row
+     * exists yet at that point (registration runs afterwards, possibly via the ABHA flow), so
+     * this is carried forward to PatientRegistrationActivity instead of being written here.
+     */
+    private var patientConsentValue: String? = null
 
     private val abhaResultLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -108,6 +123,11 @@ class PersonalConsentActivity : AppCompatActivity(), WebViewStatus {
 //                IdentificationActivity_New::class.java
 //            )
 //        )
+        // NAS-1752: this tap IS the "Patient_Consent given" moment, recorded now even though it
+        // can only be written to the DB later, once a patient uuid exists.
+        patientConsentValue = ConsentUtils.buildConsentValue(
+            sessionManager?.providerID, sessionManager?.appLanguage
+        )
         offerAbhaThenRegister()
 
 //        startRosterQuestionnaire(
@@ -149,7 +169,9 @@ class PersonalConsentActivity : AppCompatActivity(), WebViewStatus {
     }
 
     private fun continueWithoutAbha() {
-        PatientRegistrationActivity.startPatientRegistration(this)
+        PatientRegistrationActivity.startPatientRegistration(
+            this, patientConsentValue = patientConsentValue
+        )
         setResult(AppConstants.PERSONAL_CONSENT_ACCEPT)
         finish()
     }
@@ -175,19 +197,81 @@ class PersonalConsentActivity : AppCompatActivity(), WebViewStatus {
             this, abdmResult.xToken, abdmResult.cardScope, abdmResult.profile?.abhaNumber
         )
 
+        // NAS-1752: recorded now, at the moment the ABHA create/verify flow (which required its
+        // own consent checkbox before it would send an OTP) actually completed.
+        val abdmConsentValue = ConsentUtils.buildConsentValue(
+            sessionManager?.providerID, sessionManager?.appLanguage
+        )
+
         if (abdmResult.outcome ==
             AbdmOutcomes.NAVIGATE_TO_PATIENT_DETAILS_SCREEN_WITH_EXISTING_PATIENT_AFTER_COMPARISON
         ) {
+            // The ABHA matched a patient this device already has locally - write both consent
+            // attributes directly against that existing row rather than threading them through
+            // registration (this HW did just accept personal-data processing for this patient
+            // in this same interaction, so Patient_Consent is written here too, not skipped).
+            abdmResult.uuid?.takeIf { it.isNotBlank() }
+                ?.let { recordConsentForExistingPatient(it, patientConsentValue, abdmConsentValue) }
             Intent(this, PatientDetailActivity2::class.java).apply {
                 putExtra("patientUuid", abdmResult.uuid)
                 putExtra("tag", "newPatient")
             }.also { startActivity(it) }
-        } else {
+        } else if (!abdmResult.uuid.isNullOrBlank()) {
+            // Registration below opens in edit mode against this existing uuid (see
+            // startPatientRegistrationFromAbha's doc comment) and never runs generatePatientId,
+            // so the same direct write used above is needed here too.
+            recordConsentForExistingPatient(abdmResult.uuid!!, patientConsentValue, abdmConsentValue)
             PatientRegistrationActivity.startPatientRegistrationFromAbha(this, abdmResult)
+        } else {
+            // Genuinely new patient - no row exists yet anywhere. Defer both values to
+            // patient-creation time, same as the no-ABHA path.
+            PatientRegistrationActivity.startPatientRegistrationFromAbha(
+                this, abdmResult,
+                patientConsentValue = patientConsentValue,
+                abdmConsentValue = abdmConsentValue
+            )
         }
 
         setResult(AppConstants.PERSONAL_CONSENT_ACCEPT)
         finish()
+    }
+
+    /**
+     * NAS-1752 - writes Patient_Consent / ABDM_Consent directly for a patient that already has a
+     * local row, since PatientRepository#createPatientAttributes (the deferred path used for a
+     * brand-new patient) never runs for these two cases. tbl_patient_attribute has a
+     * UNIQUE(patientuuid, person_attribute_type_uuid) constraint, so re-recording consent for the
+     * same patient replaces the previous row rather than duplicating it.
+     */
+    private fun recordConsentForExistingPatient(
+        patientUuid: String, patientConsentValue: String?, abdmConsentValue: String
+    ) {
+        try {
+            val attributes = arrayListOf<PatientAttributesDTO>().apply {
+                patientConsentValue?.let {
+                    add(PatientAttributesDTO().apply {
+                        uuid = UUID.randomUUID().toString()
+                        this.patientuuid = patientUuid
+                        personAttributeTypeUuid = UuidDictionary.PATIENT_CONSENT
+                        value = it
+                    })
+                }
+                add(PatientAttributesDTO().apply {
+                    uuid = UUID.randomUUID().toString()
+                    this.patientuuid = patientUuid
+                    personAttributeTypeUuid = UuidDictionary.ABDM_CONSENT
+                    value = abdmConsentValue
+                })
+            }
+            PatientsDAO().insertPatientAttributes(attributes)
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.d(
+                "NAS1752", "consent stored for existing patient - patientUuid=$patientUuid " +
+                        "patientConsent=$patientConsentValue abdmConsent=$abdmConsentValue"
+            )
+        } catch (e: DAOException) {
+            FirebaseCrashlytics.getInstance().recordException(e)
+        }
     }
 
     override fun attachBaseContext(newBase: Context) {

--- a/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
+++ b/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
@@ -76,6 +76,7 @@ import org.intelehealth.app.models.dto.VisitDTO;
 import org.intelehealth.app.shared.BaseActivity;
 import org.intelehealth.app.syncModule.SyncUtils;
 import org.intelehealth.app.utilities.BitmapUtils;
+import org.intelehealth.app.utilities.ConsentUtils;
 import org.intelehealth.app.utilities.CustomLog;
 import org.intelehealth.app.utilities.DateAndTimeUtils;
 import org.intelehealth.app.utilities.DialogUtils;
@@ -241,6 +242,22 @@ public class VisitCreationActivity extends BaseActivity implements VisitCreation
 
         try {
             visitsDAO.insertPatientToDB(visitDTO);
+        } catch (DAOException e) {
+            FirebaseCrashlytics.getInstance().recordException(e);
+        }
+
+        // NAS-1752: record Teleconsultation_Consent against this visit. Consent was already
+        // confirmed on the TeleconsultationConsentActivity screen the user just came from -
+        // this is where it is persisted, at the same point VISIT_ABHA_ADDRESS and other visit
+        // attributes are written elsewhere in this app.
+        try {
+            String consentValue = ConsentUtils.buildConsentValue(
+                    sessionManager.getProviderID(), sessionManager.getAppLanguage());
+            new VisitAttributeListDAO().insertVisitAttributes(
+                    visitUuid, consentValue, UuidDictionary.TELECONSULTATION_CONSENT);
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.d("NAS1752", "Teleconsultation_Consent stored - visitUuid=" + visitUuid
+                    + " patientUuid=" + patientDTO.getUuid() + " value=" + consentValue);
         } catch (DAOException e) {
             FirebaseCrashlytics.getInstance().recordException(e);
         }

--- a/app/src/main/java/org/intelehealth/app/models/dto/PatientDTO.java
+++ b/app/src/main/java/org/intelehealth/app/models/dto/PatientDTO.java
@@ -119,6 +119,13 @@ public class PatientDTO implements Serializable {
     @Expose
     private String abhaAddress;
 
+    // NAS-1752 - pipe-separated consent values (see ConsentUtils), carried from
+    // PersonalConsentActivity into registration so PatientRepository can turn them into
+    // Patient_Consent / ABDM_Consent person attributes once the patient row is created. Local
+    // working values only, not part of any push/pull JSON contract, so no @SerializedName.
+    private String patientConsentValue;
+    private String abdmConsentValue;
+
     public String getAbhaNumber() {
         return abhaNumber;
     }
@@ -133,6 +140,22 @@ public class PatientDTO implements Serializable {
 
     public void setAbhaAddress(String abhaAddress) {
         this.abhaAddress = abhaAddress;
+    }
+
+    public String getPatientConsentValue() {
+        return patientConsentValue;
+    }
+
+    public void setPatientConsentValue(String patientConsentValue) {
+        this.patientConsentValue = patientConsentValue;
+    }
+
+    public String getAbdmConsentValue() {
+        return abdmConsentValue;
+    }
+
+    public void setAbdmConsentValue(String abdmConsentValue) {
+        this.abdmConsentValue = abdmConsentValue;
     }
     public String getRelativePhoneNumber() {
         return relativePhoneNumber;

--- a/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncDao.kt
+++ b/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncDao.kt
@@ -25,6 +25,7 @@ import org.intelehealth.app.database.dao.ProviderDAO
 import org.intelehealth.app.database.dao.SyncDAO
 import org.intelehealth.app.database.dao.VisitsDAO
 import org.intelehealth.app.models.pushRequestApiCall.PushRequestApiCall
+import org.intelehealth.app.utilities.CustomLog
 import org.intelehealth.app.utilities.NavigationUtils
 import org.intelehealth.app.utilities.NotificationUtils
 import org.intelehealth.app.utilities.PatientsFrameJson
@@ -154,12 +155,21 @@ class OptimizedSyncDao {
                 .PUSH_RESPONSE_API_CALL_OBSERVABLE(url, "Basic $encoded", pushRequest)
                 .blockingGet()
 
-            val data = response?.data ?: return false
+            val data = response?.data ?: run {
+                // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+                CustomLog.e("NAS1752", "push failed - response body/data was null: $response")
+                return false
+            }
 
             val patientsDAO = PatientsDAO()
             data.patientlist?.forEach { patient ->
                 runCatching {
                     patientsDAO.updateOpemmrsId(patient.openmrsId, patient.syncd.toString(), patient.uuid)
+                    // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+                    CustomLog.d(
+                        "NAS1752", "openmrsId assigned - patientUuid=${patient.uuid} " +
+                                "openmrsId=${patient.openmrsId}"
+                    )
                 }.onFailure { FirebaseCrashlytics.getInstance().recordException(it) }
             }
 
@@ -191,6 +201,10 @@ class OptimizedSyncDao {
             broadcastSyncStatus(AppConstants.SYNC_PUSH_DATA_DONE)
             true
         } catch (e: Exception) {
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            val body = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
+            CustomLog.e("NAS1752", "push failed - ${e.javaClass.simpleName}: ${e.message}" +
+                    (body?.let { " | serverBody=$it" } ?: ""))
             FirebaseCrashlytics.getInstance().recordException(e)
             broadcastSyncStatus(AppConstants.SYNC_FAILED)
             false
@@ -220,18 +234,25 @@ class OptimizedSyncDao {
                     .RESPONSE_DTO_CALL(url, "Basic $encoded").execute()
 
                 if (!response.isSuccessful) {
+                    // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+                    CustomLog.e("NAS1752", "pull failed - HTTP ${response.code()}: " +
+                            "${response.errorBody()?.string()}")
                     broadcastSyncStatus(AppConstants.SYNC_FAILED)
                     return false
                 }
 
                 val body = response.body()
                 val data = body?.data ?: run {
+                    // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+                    CustomLog.e("NAS1752", "pull failed - response body/data was null")
                     broadcastSyncStatus(AppConstants.SYNC_FAILED)
                     return false
                 }
 
                 sessionManager.setPulled(data.pullexecutedtime)
                 if (!syncDAO.SyncData(body, true)) {
+                    // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+                    CustomLog.e("NAS1752", "pull failed - syncDAO.SyncData returned false")
                     broadcastSyncStatus(AppConstants.SYNC_FAILED)
                     return false
                 }
@@ -247,6 +268,10 @@ class OptimizedSyncDao {
             broadcastSyncStatus(AppConstants.SYNC_PULL_DATA_DONE)
             true
         } catch (e: Exception) {
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            val body = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
+            CustomLog.e("NAS1752", "pull failed - ${e.javaClass.simpleName}: ${e.message}" +
+                    (body?.let { " | serverBody=$it" } ?: ""))
             FirebaseCrashlytics.getInstance().recordException(e)
             broadcastSyncStatus(AppConstants.SYNC_FAILED)
             false

--- a/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncWorker.kt
+++ b/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncWorker.kt
@@ -21,6 +21,7 @@ import org.intelehealth.app.app.AppConstants
 import org.intelehealth.app.appointment.dao.AppointmentDAO
 import org.intelehealth.app.appointment.model.AppointmentInfo
 import org.intelehealth.app.optimized_sync.network.NetworkConnectivityManager
+import org.intelehealth.app.utilities.CustomLog
 import org.intelehealth.app.utilities.SessionManager
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -55,10 +56,14 @@ class OptimizedSyncWorker(
         val powerState = PowerStateProvider(context = context)
 
         if (!networkManager.getCurrentStatus().hasInternet) {
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.e("NAS1752", "sync skipped - no internet per NetworkConnectivityManager")
             return Result.failure()
         }
 
         if (!powerState.isPowerRequirementMet()) {
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.e("NAS1752", "sync skipped - power requirement not met")
             return Result.failure()
         }
 
@@ -67,9 +72,13 @@ class OptimizedSyncWorker(
                 setForegroundAsync(getForegroundInfo()).get()
             }
             val isSyncSuccessful = OptimizedSyncDao().periodicSync()
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.d("NAS1752", "periodicSync() returned $isSyncSuccessful")
             reviewUpcomingAppointments()
             if (isSyncSuccessful) Result.success() else Result.retry()
         } catch (e: Exception) {
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.e("NAS1752", "doWork threw - ${e.javaClass.simpleName}: ${e.message}")
             Result.retry()
         }
     }

--- a/app/src/main/java/org/intelehealth/app/ui/patient/activity/PatientRegistrationActivity.kt
+++ b/app/src/main/java/org/intelehealth/app/ui/patient/activity/PatientRegistrationActivity.kt
@@ -35,6 +35,8 @@ import org.intelehealth.app.syncModule.SyncUtils
 import org.intelehealth.app.utilities.BundleKeys.Companion.PATIENT_CURRENT_STAGE
 import org.intelehealth.app.utilities.BundleKeys.Companion.PATIENT_UUID
 import org.intelehealth.app.utilities.BundleKeys.Companion.PARENT_PATIENT_UUID
+import org.intelehealth.app.utilities.BundleKeys.Companion.PATIENT_CONSENT_VALUE
+import org.intelehealth.app.utilities.BundleKeys.Companion.ABDM_CONSENT_VALUE
 import org.intelehealth.app.utilities.DateAndTimeUtils
 import org.intelehealth.app.utilities.DialogUtils
 import org.intelehealth.app.utilities.DialogUtils.CustomDialogListener
@@ -197,6 +199,12 @@ class PatientRegistrationActivity : BaseActivity() {
             reportDateOfPatientCreated = DateAndTimeUtils.currentDateTimeFormat()
 
             householdLinkingUUIDlinking = UUID.randomUUID().toString()
+
+            // NAS-1752 - carried from PersonalConsentActivity. Only read here, in the
+            // fresh-record path: an edit-mode reopen (see fetchPatientDetails) loads a patient
+            // that - if it needed these - already got them the first time it went through here.
+            patientConsentValue = intent.getStringExtra(PATIENT_CONSENT_VALUE)
+            abdmConsentValue = intent.getStringExtra(ABDM_CONSENT_VALUE)
 
             val parentPatientId = if (intent.hasExtra(PARENT_PATIENT_UUID)) intent.getStringExtra(PARENT_PATIENT_UUID)
             else null
@@ -465,15 +473,20 @@ class PatientRegistrationActivity : BaseActivity() {
         /** India only — matches development_master. Revisit if ABDM is ever deployed elsewhere. */
         private const val COUNTRY_CODE_IN = "91"
 
+        @JvmOverloads
         @JvmStatic
         fun startPatientRegistration(
             context: Context,
             patientId: String? = null,
             stage: PatientRegStage = PatientRegStage.PERSONAL,
+            // NAS-1752 - set only by PersonalConsentActivity's no-ABHA path; every other
+            // (Java) call site edits an already-registered patient and leaves this null.
+            patientConsentValue: String? = null,
         ) {
             Intent(context, PatientRegistrationActivity::class.java).apply {
                 putExtra(PATIENT_UUID, patientId)
                 putExtra(PATIENT_CURRENT_STAGE, stage)
+                putExtra(PATIENT_CONSENT_VALUE, patientConsentValue)
             }.also { context.startActivity(it) }
         }
 
@@ -490,12 +503,25 @@ class PatientRegistrationActivity : BaseActivity() {
          * uuid. The module has already written the ABHA number and address to that row via
          * linkAbha, so the fetched record arrives with them and this path needs no ABHA seeding.
          */
+        @JvmOverloads
         @JvmStatic
-        fun startPatientRegistrationFromAbha(context: Context, abdmResult: AbdmResult) {
+        fun startPatientRegistrationFromAbha(
+            context: Context,
+            abdmResult: AbdmResult,
+            // NAS-1752 - only meaningful when abdmResult.uuid is blank, i.e. this is genuinely a
+            // new local patient. When it resolved to an existing one, the activity opens in edit
+            // mode (see the uuid check above) and these are never read - the caller is expected
+            // to have written Patient_Consent / ABDM_Consent directly against that patient uuid
+            // instead, since the record already exists.
+            patientConsentValue: String? = null,
+            abdmConsentValue: String? = null,
+        ) {
             Intent(context, PatientRegistrationActivity::class.java).apply {
                 abdmResult.uuid?.takeIf { it.isNotBlank() }?.let { putExtra(PATIENT_UUID, it) }
                 putExtra(PATIENT_CURRENT_STAGE, PatientRegStage.PERSONAL)
                 putExtra(AbdmResult.EXTRA_ABDM_RESULT, abdmResult)
+                putExtra(PATIENT_CONSENT_VALUE, patientConsentValue)
+                putExtra(ABDM_CONSENT_VALUE, abdmConsentValue)
             }.also { context.startActivity(it) }
         }
 

--- a/app/src/main/java/org/intelehealth/app/ui/patient/data/PatientRepository.kt
+++ b/app/src/main/java/org/intelehealth/app/ui/patient/data/PatientRepository.kt
@@ -9,6 +9,8 @@ import org.intelehealth.app.models.dto.PatientAttributeTypeMasterDTO
 import org.intelehealth.app.models.dto.PatientAttributesDTO
 import org.intelehealth.app.models.dto.PatientDTO
 import org.intelehealth.app.optimized_sync.OptimizedSyncWorker
+import org.intelehealth.app.utilities.CustomLog
+import org.intelehealth.app.utilities.UuidDictionary
 import org.intelehealth.config.presenter.fields.data.RegFieldRepository
 import org.intelehealth.config.room.dao.PatientRegFieldDao
 import java.util.UUID
@@ -28,6 +30,11 @@ class PatientRepository(
         bindPatientAttributes(patient).let {
             val flag = patientsDao.insertPatientToDB(it, it.uuid)
             val flag2 = ImagesDAO().insertPatientProfileImages(it.patientPhoto, it.uuid)
+            // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
+            CustomLog.d(
+                "NAS1752", "patient created - uuid=${it.uuid} name=${it.firstname} ${it.lastname} " +
+                        "patientConsent=${it.patientConsentValue} abdmConsent=${it.abdmConsentValue}"
+            )
             syncOnServer()
             return flag && flag2
         }
@@ -277,6 +284,28 @@ class PatientRepository(
                     patient.contactType
                 )
             )
+
+            // NAS-1752 - Patient_Consent / ABDM_Consent. Unlike the attributes above, these two
+            // attribute types are not (yet) seeded in tbl_patient_attribute_master locally, so
+            // they're addressed directly by UuidDictionary UUID instead of going through
+            // getUuidForAttribute(name), which would resolve to null for a type this app has
+            // never synced down. Blank when the corresponding consent wasn't given on this save
+            // (e.g. patient created without going through the ABHA flow), and dropped by the
+            // filter below like every other unfilled attribute.
+            add(
+                createPatientAttributeWithTypeUuid(
+                    patient.uuid,
+                    UuidDictionary.PATIENT_CONSENT,
+                    patient.patientConsentValue
+                )
+            )
+            add(
+                createPatientAttributeWithTypeUuid(
+                    patient.uuid,
+                    UuidDictionary.ABDM_CONSENT,
+                    patient.abdmConsentValue
+                )
+            )
         }.filter { it.value.isNullOrBlank().not() }
 
     private fun createPatientAttribute(
@@ -287,6 +316,18 @@ class PatientRepository(
         uuid = UUID.randomUUID().toString()
         patientuuid = patientId
         personAttributeTypeUuid = patientsDao.getUuidForAttribute(attrName)
+        this.value = value
+    }
+
+    /** Like [createPatientAttribute], but for an attribute type not resolvable by name locally. */
+    private fun createPatientAttributeWithTypeUuid(
+        patientId: String,
+        attributeTypeUuid: String,
+        value: String?
+    ) = PatientAttributesDTO().apply {
+        uuid = UUID.randomUUID().toString()
+        patientuuid = patientId
+        personAttributeTypeUuid = attributeTypeUuid
         this.value = value
     }
 

--- a/app/src/main/java/org/intelehealth/app/utilities/BundleKeys.kt
+++ b/app/src/main/java/org/intelehealth/app/utilities/BundleKeys.kt
@@ -31,5 +31,10 @@ class BundleKeys {
         const val IS_EDIT_MODE = "isEditMode"
         const val IS_PREGNANCY_MODE = "isPregnant"
 
+        // NAS-1752 - consent values built by ConsentUtils, carried from PersonalConsentActivity
+        // into PatientRegistrationActivity so they can be seeded onto the new PatientDTO.
+        const val PATIENT_CONSENT_VALUE = "patientConsentValue"
+        const val ABDM_CONSENT_VALUE = "abdmConsentValue"
+
     }
 }

--- a/app/src/main/java/org/intelehealth/app/utilities/ConsentUtils.kt
+++ b/app/src/main/java/org/intelehealth/app/utilities/ConsentUtils.kt
@@ -1,0 +1,35 @@
+package org.intelehealth.app.utilities
+
+import org.intelehealth.core.utility.DateTimeUtils
+import java.util.Date
+import java.util.TimeZone
+
+/**
+ * NAS-1752 - builds the pipe-separated consent value shared by Patient, Teleconsultation and
+ * ABDM consent:
+ *
+ * `Date & Time | HW User_UUID | language | status | application`
+ *
+ * e.g. `25-08-2026 19:45:45 | 5f2c1b3a-... | mr | active | NAS-mobile`
+ *
+ * Centralised here so the format is defined once instead of being hand-built at each of the
+ * three call sites (PersonalConsentActivity, VisitCreationActivity, the ABDM consent flow).
+ */
+object ConsentUtils {
+
+    const val STATUS_ACTIVE = "active"
+    const val APPLICATION_NAS_MOBILE = "NAS-mobile"
+
+    @JvmStatic
+    @JvmOverloads
+    fun buildConsentValue(
+        hwUuid: String?,
+        language: String?,
+        status: String = STATUS_ACTIVE,
+        application: String = APPLICATION_NAS_MOBILE,
+        date: Date = Date()
+    ): String {
+        val dateTime = DateTimeUtils.formatDate(date, DateTimeUtils.DD_MM_YYYY_HH_MM_SS, TimeZone.getDefault())
+        return "$dateTime | ${hwUuid.orEmpty()} | ${language.orEmpty()} | $status | $application"
+    }
+}

--- a/app/src/main/java/org/intelehealth/app/utilities/UuidDictionary.java
+++ b/app/src/main/java/org/intelehealth/app/utilities/UuidDictionary.java
@@ -101,5 +101,14 @@ public class UuidDictionary {
     // concept uuid for the AI generated JSON format of the visit summary
     public static final String AI_JSON_FORMAT_VISIT_SUMMARY_CONCEPT_UUID = "1f770363-262e-4d01-b1df-3eb164d575ef";
 
+    // Consent attributes - NAS-1752. Person attribute types unless noted otherwise. These UUIDs
+    // must be provisioned as attribute types on the OpenMRS server; this app only ever writes
+    // values tagged with them, it never defines them.
+    /** Person attribute type - "Patient_Consent". */
+    public static final String PATIENT_CONSENT = "11b990b9-2798-477a-9aad-073e5459f5d3";
+    /** Visit attribute type - "Teleconsultation_Consent". */
+    public static final String TELECONSULTATION_CONSENT = "ddabcccc-1554-4fb5-bfa2-de596b72a64c";
+    /** Person attribute type - "ABDM_Consent". */
+    public static final String ABDM_CONSENT = "9c8f0974-615e-4dd2-82ea-40cbec9e821b";
 
 }

--- a/core/src/main/java/org/intelehealth/core/utility/DateTimeUtils.java
+++ b/core/src/main/java/org/intelehealth/core/utility/DateTimeUtils.java
@@ -34,6 +34,9 @@ public class DateTimeUtils {
     public static final String MMM_DD_YYYY_FORMAT = "MMM dd, yyyy";
 
     public static final String CALL_LOG_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss";
+
+    /** Consent-record timestamp format, e.g. "25-08-2026 19:45:45" (NAS-1752). */
+    public static final String DD_MM_YYYY_HH_MM_SS = "dd-MM-yyyy HH:mm:ss";
     @SuppressLint("SimpleDateFormat")
     public static SimpleDateFormat getSimpleDateFormat(String format, TimeZone timeZone) {
         SimpleDateFormat sdf = new SimpleDateFormat(format);


### PR DESCRIPTION
- Patient_Consent (person_attribute, UUID 11b990b9-2798-477a-9aad-073e5459f5d3): captured on the Processing Personal Data screen's Accept click, then carried through registration and written once the patient record is actually created, since no patient uuid exists yet at click time.

- Teleconsultation_Consent (visit_attribute, UUID ddabcccc-1554-4fb5-bfa2-de596b72a64c): written immediately at visit creation, alongside the app's existing visit-attribute writes (e.g. VISIT_ABHA_ADDRESS).

- ABDM_Consent (person_attribute, UUID 9c8f0974-615e-4dd2-82ea-40cbec9e821b): written when the ABHA create/verify flow completes. For a genuinely new patient (no local row exists during the ABHA/OTP flow) this is deferred the same way as Patient_Consent; for a flow that resolves to an already-registered patient, it's written directly against that patient's existing row.