### PR TITLE
PR-993-NAS-1683-Fixed "Remark: null" fix across all follow-up surfaces.

### DIFF
--- a/app/src/main/java/org/intelehealth/app/activities/prescription/thermalprinter/PrintViewPrescription.kt
+++ b/app/src/main/java/org/intelehealth/app/activities/prescription/thermalprinter/PrintViewPrescription.kt
@@ -327,7 +327,17 @@ class PrintViewPrescription(
 
                 val remainingStr = splitFollowDate
                     .drop(1)
-                    .mapNotNull { it.trim().takeIf { str -> str.isNotEmpty() && str != "null" } }
+                    .mapNotNull { segment ->
+                        val trimmed = segment.trim()
+                        when {
+                            trimmed.isEmpty() || trimmed.equals("null", ignoreCase = true) -> null
+                            // A blank doctor remark syncs down as a literal "Remark: null" -
+                            // show "NA" here too, matching the Follow-up Visits screen, the
+                            // end-visit reminder, and the WhatsApp preview/PDF.
+                            trimmed.matches(Regex("(?i)Remark:\\s*(null)?\\s*")) -> "Remark: NA"
+                            else -> trimmed
+                        }
+                    }
                     .joinToString(", ")
                 Log.d(TAG, "kzfollowUpWeb: remainingStr : $remainingStr")
 

--- a/app/src/main/java/org/intelehealth/app/activities/visit/VisitActivity.java
+++ b/app/src/main/java/org/intelehealth/app/activities/visit/VisitActivity.java
@@ -94,7 +94,16 @@ public class VisitActivity extends BaseActivity implements
 
         if (activeStatus != null) {
             mFeatureActiveStatus = activeStatus;
-            featureStatusListener.onFeatureStatusReady(activeStatus);
+            // The feature-status LiveData can fire before VisitReceivedFragment has
+            // attached and called setFeatureStatusListener() - e.g. when the value is
+            // already cached and Room/LiveData delivers it synchronously on subscribe,
+            // which is timing-dependent (seen on some emulators, not on others). Safe
+            // to skip here: mFeatureActiveStatus is cached above, and
+            // setFeatureStatusListener() already delivers it as soon as a listener
+            // registers late.
+            if (featureStatusListener != null) {
+                featureStatusListener.onFeatureStatusReady(activeStatus);
+            }
         }
     }
     public FeatureActiveStatus getFeatureActiveStatus() {

--- a/app/src/main/java/org/intelehealth/app/utilities/VisitUtils.java
+++ b/app/src/main/java/org/intelehealth/app/utilities/VisitUtils.java
@@ -15,7 +15,12 @@ public class VisitUtils {
 
             if (followUpDate != null && !followUpDate.equalsIgnoreCase("") && !followUpDate.equalsIgnoreCase("No")) {
 
-                new DialogUtils().showCommonDialog(activityContext, R.drawable.ui2_ic_exit_app, activityContext.getResources().getString(R.string.alert_txt), activityContext.getString(R.string.visit_summary_follow_up_reminder) + " " + followUpDate, true, activityContext.getResources().getString(R.string.ok), activityContext.getResources().getString(R.string.cancel), new DialogUtils.CustomDialogListener() {
+                // The synced follow-up value ends in a literal "Remark: null" when the
+                // doctor leaves the remark blank - show "NA" here too, matching the
+                // Follow-up Visits screen and the WhatsApp preview/PDF.
+                String followUpDisplayText = followUpDate.replaceAll("(?i)Remark:\\s*(null)?\\s*$", "Remark: NA");
+
+                new DialogUtils().showCommonDialog(activityContext, R.drawable.ui2_ic_exit_app, activityContext.getResources().getString(R.string.alert_txt), activityContext.getString(R.string.visit_summary_follow_up_reminder) + " " + followUpDisplayText, true, activityContext.getResources().getString(R.string.ok), activityContext.getResources().getString(R.string.cancel), new DialogUtils.CustomDialogListener() {
                     @Override
                     public void onDialogActionDone(int action) {
                         Intent intent = new Intent(activityContext, PatientSurveyActivity_New.class);


### PR DESCRIPTION
- Fixed "Remark: null" fix for End Visit Alert Dialog and for View/Print screen.
- Fixed a NullPointerException crash on  onFeatureActiveStatusLoaded().