### PR TITLE
Improve initial sync reliability, add loading animation, remove legacy Q&A visit summary code

### DIFF
--- a/app/src/main/java/org/intelehealth/app/activities/homeActivity/HomeScreenActivity_New.java
+++ b/app/src/main/java/org/intelehealth/app/activities/homeActivity/HomeScreenActivity_New.java
@@ -66,7 +66,6 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import org.intelehealth.app.optimized_sync.OptimizedSyncWorker;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestBuilder;
@@ -96,6 +95,7 @@ import org.intelehealth.app.database.dao.SyncDAO;
 import org.intelehealth.app.models.CheckAppUpdateRes;
 import org.intelehealth.app.models.dto.ProviderAttributeDTO;
 import org.intelehealth.app.models.dto.ProviderDTO;
+import org.intelehealth.app.optimized_sync.OptimizedSyncWorker;
 import org.intelehealth.app.profile.MyProfileActivity;
 import org.intelehealth.app.services.firebase_services.DeviceInfoUtils;
 import org.intelehealth.app.shared.BaseActivity;
@@ -1778,6 +1778,7 @@ public class HomeScreenActivity_New extends BaseActivity implements NetworkUtils
         //new Thread(() -> {
         String lastSync = sessionManager.getLastSyncDateTime();
         String lastSyncText = context.getString(R.string.last_sync) + ": " + lastSync;
+        CustomLog.e(TAG, "updateLastSyncTime: lastSyncText : " + lastSyncText);
         tvAppLastSync.setText(lastSyncText);
         // Update UI on main thread
         //new Handler(Looper.getMainLooper()).post(() -> tvAppLastSync.setText(lastSyncText));

--- a/app/src/main/java/org/intelehealth/app/app/AppConstants.java
+++ b/app/src/main/java/org/intelehealth/app/app/AppConstants.java
@@ -37,7 +37,7 @@ public class AppConstants {
     public static final String MESSAGE_PROGRESS = "message_progress";
     public static final String MCC_USER_TYPE = "mcc";
 
-    public static final int PAGE_LIMIT = 1000;
+    public static final int PAGE_LIMIT = 100;
 
     public static final long FOLLOW_UP_SCHEDULE_ONE_DURATION = 5;
     public static final long FOLLOW_UP_SCHEDULE_TWO_DURATION = 24;

--- a/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
+++ b/app/src/main/java/org/intelehealth/app/ayu/visit/VisitCreationActivity.java
@@ -2217,11 +2217,13 @@ public class VisitCreationActivity extends BaseActivity implements VisitCreation
         insertJsonFormattedVisitSummary();
         CustomLog.i(TAG, "insertLocalEnFormatQAValues");
         boolean isInserted = false;
-        try {
+        // Q/A visit sumamry is not required after JSON format is implemented, but keeping this code for reference in case we need to revert back to the old format.
+
+        /*try {
             // ✅ In edit mode, restore any ...En vars that were NOT re-saved this session
-            /*if (mIsEditMode) {
+            *//*if (mIsEditMode) {
                 loadExistingAiSummaryIntoEnVars();
-            }*/
+            }*//*
             ObsDAO obsDAO = new ObsDAO();
             String insertDbEnValue = "Visit Reason (Chief Complaint):\n"  + insertionLocaleEn + "\n" + "Physical Examination:\n"+ physicalStringLocaleEn + "\n" + "Patient Medical History:\n"+ patientHistoryLocaleEn + "\n"  + "Family History:\n"+ familyHistoryLocaleEn;
 
@@ -2245,7 +2247,7 @@ public class VisitCreationActivity extends BaseActivity implements VisitCreation
 
         } catch (DAOException e) {
             FirebaseCrashlytics.getInstance().recordException(e);
-        }
+        }*/
 
         return isInserted;
     }

--- a/app/src/main/java/org/intelehealth/app/database/dao/SyncDAO.java
+++ b/app/src/main/java/org/intelehealth/app/database/dao/SyncDAO.java
@@ -358,6 +358,7 @@ public class SyncDAO {
         if (sync) {
             int nextPageNo = response.body().getData().getPageNo();
             int totalCount = response.body().getData().getTotalCount();
+            Logger.logD("pulldata", "populatePullSuccessBackground nextPageNo: " + nextPageNo + ", totalCount: " + totalCount);
             if (nextPageNo != -1) {
                 pullData_Background(context, nextPageNo);
               //  return null;

--- a/app/src/main/java/org/intelehealth/app/networkApiCalls/ApiClient.java
+++ b/app/src/main/java/org/intelehealth/app/networkApiCalls/ApiClient.java
@@ -48,9 +48,9 @@ public class ApiClient {
         return new OkHttpClient.Builder()
                 .addInterceptor(loggingInterceptor)
                 .addInterceptor(new TokenSetupInterceptor())
-                .connectTimeout(60, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
-                .writeTimeout(60, TimeUnit.SECONDS)
+                .connectTimeout(45, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS) // expanded timeouts for large responses
+                .writeTimeout(120, TimeUnit.SECONDS)
                 .build();
     }
 

--- a/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncDao.kt
+++ b/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncDao.kt
@@ -9,10 +9,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import org.intelehealth.app.BuildConfig
 import org.intelehealth.app.app.AppConstants
 import org.intelehealth.app.app.IntelehealthApplication
@@ -31,6 +27,12 @@ import org.intelehealth.app.utilities.NotificationUtils
 import org.intelehealth.app.utilities.PatientsFrameJson
 import org.intelehealth.app.utilities.SessionManager
 import org.intelehealth.app.utilities.UrlModifiers
+import retrofit2.Response
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * A full sync run as one blocking sequence.
@@ -164,7 +166,11 @@ class OptimizedSyncDao {
             val patientsDAO = PatientsDAO()
             data.patientlist?.forEach { patient ->
                 runCatching {
-                    patientsDAO.updateOpemmrsId(patient.openmrsId, patient.syncd.toString(), patient.uuid)
+                    patientsDAO.updateOpemmrsId(
+                        patient.openmrsId,
+                        patient.syncd.toString(),
+                        patient.uuid
+                    )
                     // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
                     CustomLog.d(
                         "NAS1752", "openmrsId assigned - patientUuid=${patient.uuid} " +
@@ -181,13 +187,23 @@ class OptimizedSyncDao {
 
             val encounterDAO = EncounterDAO()
             data.encounterlist?.forEach { encounter ->
-                runCatching { encounterDAO.updateEncounterSync(encounter.syncd.toString(), encounter.uuid) }
+                runCatching {
+                    encounterDAO.updateEncounterSync(
+                        encounter.syncd.toString(),
+                        encounter.uuid
+                    )
+                }
                     .onFailure { FirebaseCrashlytics.getInstance().recordException(it) }
             }
 
             val appointmentDAO = AppointmentDAO()
             data.appointmentList?.forEach { appointment ->
-                runCatching { appointmentDAO.updateAppointmentSync(appointment.visitUuid, appointment.sync) }
+                runCatching {
+                    appointmentDAO.updateAppointmentSync(
+                        appointment.visitUuid,
+                        appointment.sync
+                    )
+                }
                     .onFailure { FirebaseCrashlytics.getInstance().recordException(it) }
             }
 
@@ -203,7 +219,8 @@ class OptimizedSyncDao {
         } catch (e: Exception) {
             // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
             val body = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
-            CustomLog.e("NAS1752", "push failed - ${e.javaClass.simpleName}: ${e.message}" +
+            CustomLog.e(
+                "NAS1752", "push failed - ${e.javaClass.simpleName}: ${e.message}" +
                     (body?.let { " | serverBody=$it" } ?: ""))
             FirebaseCrashlytics.getInstance().recordException(e)
             broadcastSyncStatus(AppConstants.SYNC_FAILED)
@@ -227,16 +244,26 @@ class OptimizedSyncDao {
         return try {
             while (true) {
                 val url = BuildConfig.SERVER_URL + "/EMR-Middleware/webapi/pull/pulldata/" +
-                    sessionManager.locationUuid + "/" + sessionManager.pullExcutedTime +
-                    "/" + pageNo + "/" + AppConstants.PAGE_LIMIT
-
-                val response = AppConstants.apiInterface
-                    .RESPONSE_DTO_CALL(url, "Basic $encoded").execute()
+                        sessionManager.locationUuid + "/" + sessionManager.pullExcutedTime +
+                        "/" + pageNo + "/" + AppConstants.PAGE_LIMIT
+                CustomLog.e(
+                    "OptimizedSyncDao" + "pullDataBackgroundSync",
+                    "Before API call: pageNo=$pageNo, url=$url"
+                )
+                val response = executePageWithRetry {
+                    AppConstants.apiInterface.RESPONSE_DTO_CALL(url, "Basic $encoded").execute()
+                }
+                CustomLog.e(
+                    "OptimizedSyncDao" + "pullDataBackgroundSync",
+                    "After API call: pageNo=$pageNo, url=$url"
+                )
 
                 if (!response.isSuccessful) {
                     // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
-                    CustomLog.e("NAS1752", "pull failed - HTTP ${response.code()}: " +
-                            "${response.errorBody()?.string()}")
+                    CustomLog.e(
+                        "NAS1752", "pull failed - HTTP ${response.code()}: " +
+                                "${response.errorBody()?.string()}"
+                    )
                     broadcastSyncStatus(AppConstants.SYNC_FAILED)
                     return false
                 }
@@ -250,32 +277,75 @@ class OptimizedSyncDao {
                 }
 
                 sessionManager.setPulled(data.pullexecutedtime)
+                CustomLog.e(
+                    "OptimizedSyncDao",
+                    "pullDataBackgroundSync: pageNo=$pageNo, pullexecutedtime=${data.pullexecutedtime}"
+                )
                 if (!syncDAO.SyncData(body, true)) {
                     // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
                     CustomLog.e("NAS1752", "pull failed - syncDAO.SyncData returned false")
                     broadcastSyncStatus(AppConstants.SYNC_FAILED)
                     return false
                 }
+                CustomLog.e(
+                    "OptimizedSyncDao",
+                    "pullDataBackgroundSync completed for pageNo=$pageNo"
+                )
 
                 val nextPageNo = data.pageNo
+                CustomLog.e(
+                    "OptimizedSyncDao",
+                    "pullDataBackgroundSync: pageNo=$pageNo, nextPageNo=$nextPageNo"
+                )
                 if (nextPageNo == -1) break
                 pageNo = nextPageNo
             }
 
             sessionManager.setPullExcutedTime(sessionManager.isPulled)
             sessionManager.setLastPulledDateTime(AppConstants.dateAndTimeUtils.currentDateTimeInHome())
+            //sessionManager.setLastSyncDateTime(AppConstants.dateAndTimeUtils.currentDateTimeInHome())
+            sessionManager.setLastSyncDateTime(
+                AppConstants.dateAndTimeUtils.getcurrentDateTime(
+                    sessionManager.getAppLanguage()
+                )
+            )
+
             sessionManager.setPullSyncFinished(true)
             broadcastSyncStatus(AppConstants.SYNC_PULL_DATA_DONE)
             true
         } catch (e: Exception) {
             // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
             val body = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
-            CustomLog.e("NAS1752", "pull failed - ${e.javaClass.simpleName}: ${e.message}" +
+
+            CustomLog.e(
+                "NAS1752", "pull failed - ${e.javaClass.simpleName}: ${e.message}" +
                     (body?.let { " | serverBody=$it" } ?: ""))
             FirebaseCrashlytics.getInstance().recordException(e)
             broadcastSyncStatus(AppConstants.SYNC_FAILED)
             false
         }
+    }
+
+    /**
+     * Retries a single page fetch on transient network failures (timeouts, dropped connections)
+     * instead of letting one bad page abort the whole multi-page pull. Rethrows the last IOException
+     * once attempts are exhausted so the caller's existing catch block handles it unchanged.
+     */
+    private fun <T> executePageWithRetry(maxAttempts: Int = PULL_PAGE_MAX_ATTEMPTS, block: () -> Response<T>): Response<T> {
+        repeat(maxAttempts) { attempt ->
+            try {
+                return block()
+            } catch (e: IOException) {
+                CustomLog.e(
+                    "NAS1752",
+                    "pull page attempt ${attempt + 1}/$maxAttempts failed - " +
+                        "${e.javaClass.simpleName}: ${e.message}"
+                )
+                if (attempt == maxAttempts - 1) throw e
+                Thread.sleep(PULL_PAGE_RETRY_BACKOFF_MS * (attempt + 1))
+            }
+        }
+        error("unreachable")
     }
 
     private fun patientProfileImagesPushSync(): Boolean {
@@ -368,7 +438,10 @@ class OptimizedSyncDao {
         voidedObsImages.forEach { voidedObsImage ->
             runCatching {
                 AppConstants.apiInterface
-                    .DELETE_OBS_IMAGE(urlModifiers.obsImageDeleteUrl(voidedObsImage), "Basic $encoded")
+                    .DELETE_OBS_IMAGE(
+                        urlModifiers.obsImageDeleteUrl(voidedObsImage),
+                        "Basic $encoded"
+                    )
                     .ignoreElements()
                     .blockingAwait()
             }.onFailure {
@@ -403,11 +476,11 @@ class OptimizedSyncDao {
     private fun isDataPresent(request: PushRequestApiCall?): Boolean {
         if (request == null) return false
         return request.patients?.isNotEmpty() == true ||
-            request.persons?.isNotEmpty() == true ||
-            request.visits?.isNotEmpty() == true ||
-            request.encounters?.isNotEmpty() == true ||
-            request.providers?.isNotEmpty() == true ||
-            request.appointments?.isNotEmpty() == true
+                request.persons?.isNotEmpty() == true ||
+                request.visits?.isNotEmpty() == true ||
+                request.encounters?.isNotEmpty() == true ||
+                request.providers?.isNotEmpty() == true ||
+                request.appointments?.isNotEmpty() == true
     }
 
     private fun broadcastSyncStatus(status: Int) {
@@ -420,5 +493,7 @@ class OptimizedSyncDao {
 
     private companion object {
         const val THIRTY_DAYS_IN_MILLIS = 30L * 24 * 60 * 60 * 1000
+        const val PULL_PAGE_MAX_ATTEMPTS = 3
+        const val PULL_PAGE_RETRY_BACKOFF_MS = 2000L
     }
 }

--- a/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncWorker.kt
+++ b/app/src/main/java/org/intelehealth/app/optimized_sync/OptimizedSyncWorker.kt
@@ -75,13 +75,24 @@ class OptimizedSyncWorker(
             // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
             CustomLog.d("NAS1752", "periodicSync() returned $isSyncSuccessful")
             reviewUpcomingAppointments()
-            if (isSyncSuccessful) Result.success() else Result.retry()
+            if (isSyncSuccessful) Result.success() else retryOrGiveUp()
         } catch (e: Exception) {
             // TODO(NAS-1752): temporary QA logging, remove once consent testing is done.
             CustomLog.e("NAS1752", "doWork threw - ${e.javaClass.simpleName}: ${e.message}")
-            Result.retry()
+            retryOrGiveUp()
         }
     }
+
+    /**
+     * Retries up to [MAX_SYNC_ATTEMPTS] times before giving up.
+     *
+     * A unique one-time sync is chained via APPEND_OR_REPLACE, so a later save's sync waits for an
+     * earlier one to reach a terminal state before it can even start. Without a cap, a persistently
+     * failing sync (e.g. a run of network timeouts) would return Result.retry() forever and never
+     * reach one, leaving every sync queued behind it permanently BLOCKED.
+     */
+    private fun retryOrGiveUp(): Result =
+        if (runAttemptCount < MAX_SYNC_ATTEMPTS) Result.retry() else Result.failure()
 
     /**
      * Warns about appointments starting within the next three quarters of an hour and drops the ones
@@ -151,6 +162,7 @@ class OptimizedSyncWorker(
         private const val MINUTES_BEFORE_APPOINTMENT_REMINDER = 45L
 
         private const val KEY_RUN_IN_FOREGROUND = "run_in_foreground"
+        private const val MAX_SYNC_ATTEMPTS = 5
 
         /**
          * Both schedules carry the connectivity constraint the requests they replace were built with,

--- a/app/src/main/java/org/intelehealth/app/services/InitialSyncIntentService.java
+++ b/app/src/main/java/org/intelehealth/app/services/InitialSyncIntentService.java
@@ -13,7 +13,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.google.gson.Gson;
 
 import org.intelehealth.app.R;
-import org.intelehealth.app.activities.visit.PrescriptionActivity;
 import org.intelehealth.app.app.AppConstants;
 import org.intelehealth.app.app.IntelehealthApplication;
 import org.intelehealth.app.database.dao.SyncDAO;
@@ -69,19 +68,21 @@ public class InitialSyncIntentService extends IntentService {
         } catch (DAOException e) {
             FirebaseCrashlytics.getInstance().recordException(e);
         }
-        Log.d("TAG", "onHandleIntentsync: "+sync);
+        CustomLog.e("TAG", "onHandleIntentsync: "+sync);
         if (sync) {
 
             int nextPageNo = responseDTO.getData().getPageNo();
             int totalCount = responseDTO.getData().getTotalCount();
             int percentage = 0; // this should be only in initialSync....
+            CustomLog.e("pulldata", "nextPageNo: " + nextPageNo + ", totalCount: " + totalCount);
 
             if (nextPageNo != -1) {
                 percentage = (int) Math.round(nextPageNo * AppConstants.PAGE_LIMIT * 100.0/totalCount);
                 Logger.logD(SyncDAO.PULL_ISSUE, "percentage: " + percentage);
+                CustomLog.e("pulldata", "percentage: " + percentage);
                 SyncDAO.setProgress(percentage);
                 syncDAO.pullDataBackgroundService(IntelehealthApplication.getAppContext(), fromActivity, nextPageNo);
-                Log.d("TAG", "onHandleIntent: isFirstPageCalled : "+isFirstPageCalled);
+                CustomLog.e("TAG", "onHandleIntent: isFirstPageCalled : "+isFirstPageCalled);
 
             }else {
                 percentage = 100;

--- a/app/src/main/java/org/intelehealth/app/ui/initialsync/InitialSyncActivity.kt
+++ b/app/src/main/java/org/intelehealth/app/ui/initialsync/InitialSyncActivity.kt
@@ -1,10 +1,13 @@
 package org.intelehealth.app.ui.initialsync
 
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +27,7 @@ import java.util.concurrent.Executors
 
 class InitialSyncActivity : AppCompatActivity() {
     private lateinit var binding: ActivityInitialSyncBinding
+    private var dotAnimators: List<ObjectAnimator> = emptyList()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,6 +47,29 @@ class InitialSyncActivity : AppCompatActivity() {
             progressIndicator.progress = 0 //default
 
         }
+        startDotsAnimation()
+    }
+
+    /**
+     * Pulses the three dots below "Syncing" on a staggered, endless loop so the screen still reads as
+     * active during the long stretches between progress broadcasts.
+     */
+    private fun startDotsAnimation() {
+        val dots = listOf(binding.dot1, binding.dot2, binding.dot3)
+        dotAnimators = dots.mapIndexed { index, dot ->
+            ObjectAnimator.ofFloat(dot, View.ALPHA, 0.3f, 1f).apply {
+                duration = DOT_PULSE_DURATION_MS
+                startDelay = index * DOT_PULSE_STAGGER_MS
+                repeatCount = ValueAnimator.INFINITE
+                repeatMode = ValueAnimator.REVERSE
+                start()
+            }
+        }
+    }
+
+    private fun stopDotsAnimation() {
+        dotAnimators.forEach { it.cancel() }
+        dotAnimators = emptyList()
     }
 
     private fun doWork() {
@@ -77,6 +104,7 @@ class InitialSyncActivity : AppCompatActivity() {
     private fun handleSyncCompletion() {
         SyncDAO.getSyncProgress_LiveData().removeObserver(syncObserver)
         runOnUiThread {
+            stopDotsAnimation()
             binding.txtProgressTask.text = getString(R.string.sync_completed)
             navigateToHomeScreen()
         }
@@ -100,5 +128,15 @@ class InitialSyncActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             task()
         }
+    }
+
+    override fun onDestroy() {
+        stopDotsAnimation()
+        super.onDestroy()
+    }
+
+    private companion object {
+        const val DOT_PULSE_DURATION_MS = 400L
+        const val DOT_PULSE_STAGGER_MS = 150L
     }
 }

--- a/app/src/main/res/layout/activity_initial_sync.xml
+++ b/app/src/main/res/layout/activity_initial_sync.xml
@@ -101,6 +101,38 @@
             app:layout_constraintTop_toBottomOf="@id/progressIndicator"
             tools:text="Downloading..." />
 
+        <LinearLayout
+            android:id="@+id/dotsContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/std_8dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/txtProgressTask">
+
+            <View
+                android:id="@+id/dot1"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginEnd="6dp"
+                android:background="@drawable/dot_white" />
+
+            <View
+                android:id="@+id/dot2"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginEnd="6dp"
+                android:background="@drawable/dot_white" />
+
+            <View
+                android:id="@+id/dot3"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:background="@drawable/dot_white" />
+        </LinearLayout>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnRetryDownload"
             style="@style/Widget.MaterialComponents.Button.TextButton"
@@ -116,6 +148,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/txtProgressTask" />
+            app:layout_constraintTop_toBottomOf="@id/dotsContainer" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
Improve initial sync reliability, add loading animation, remove legacy Q&A visit summary code
Retry failed page pulls, cap worker retries so a stuck sync doesn't block the queue, raise read/write timeouts to 120s, and show a pulsing dot animation while syncing. Also comments out the old Q&A-based visit summary insertion now that the JSON format visit summary has replaced it.